### PR TITLE
End to end processing of images to produce data csv

### DIFF
--- a/microscopium/main.py
+++ b/microscopium/main.py
@@ -15,7 +15,6 @@ from skimage import img_as_ubyte
 import toolz as tz
 from sklearn import neighbors
 from sklearn.preprocessing import StandardScaler
-import umap
 
 # local imports
 from . import config
@@ -256,10 +255,7 @@ def run_features(args):
     out_path = make_output_dir(settings['global']['output-dir'], src_dir)
 
     # for each image, compute features (as per config function), save
-    # image_features = output_features(ims, src['url'], out_path, feature_map)
-
-    # temporarily load output csv so as not to compute features
-    image_features = pd.read_csv(out_path + "/features.csv")
+    image_features = output_features(ims, src['url'], out_path, feature_map)
 
     out_df = pd.concat([src['index'], src['url'], src['group']], axis=1)
 

--- a/microscopium/serve.py
+++ b/microscopium/serve.py
@@ -204,7 +204,7 @@ def embedding(source, settings):
             group_filter = GroupFilter(column_name=color_column, group=group)
             view = CDSView(source=source, filters=[group_filter])
             glyphs = embed.circle(x="x", y="y",
-                                  source=source, view=view, size=10,
+                                  source=source, view=view, size=glyph_size,
                                   color=my_colors[i], legend=group)
         embed.legend.location = "top_right"
         embed.legend.click_policy = "hide"


### PR DESCRIPTION
Add ability to use
`mic features **data.csv** -S **settings.yaml**` to

- load images as listed in data.csv
- apply feature map as listed in settings.yaml
- apply dimension reductions as listed in settings.yaml
- save features and 'serveable' data to separate csvs in output directory as specified in settings.yaml

Data can then be served using
`python -m microscopium.serve **data.csv** -c **settings.yaml**
`